### PR TITLE
Ajouts Delay Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pour une nouvelle installation, utilisez `stable`.
 - Custom Formats `INTL` pour les trackers internationaux.
 - Tiers FR inspirés et recoupés avec plusieurs sources francophones.
 - Profils FR basés sur la logique Dictionarry V2.
-- Media Management et Delay Profiles alignés sur Dictionarry.
+- Media Management aligné sur Dictionarry et Delay Profiles FR prêts à l'emploi.
 - Profils anglophones et tiers US retirés de la publication V2 FR pour garder une base plus légère.
 
 ## Profils disponibles

--- a/docs/scoring-and-media.md
+++ b/docs/scoring-and-media.md
@@ -80,9 +80,25 @@ La DB conserve la logique Media Management de Dictionarry V2:
 
 - presets `Radarr` et `Sonarr`;
 - preset `Radarr / Editionless`;
-- Delay Profiles `Radarr` et `Sonarr` en `prefer_torrent`;
-- délai de `360` minutes;
+- Delay Profiles `Radarr` et `Sonarr` en `prefer_torrent`, conservés pour compatibilité;
+- Delay Profiles FR supplémentaires: `Ratio Boost`, `Balanced`, `Quality`;
 - protection `Full Disc` contre certaines correspondances incorrectes.
+
+## Delay Profiles
+
+La DB fournit plusieurs Delay Profiles pour adapter le délai à votre usage:
+
+```text
+Ratio Boost : torrent immédiat, usenet retardé de 360 minutes
+Balanced    : torrent et usenet retardés de 120 minutes
+Quality     : torrent et usenet retardés de 360 minutes
+```
+
+`Quality` reprend la logique Dictionarry: attendre plus longtemps laisse davantage de temps aux meilleures releases pour apparaître.
+
+`Balanced` réduit l'attente tout en gardant un petit délai pour éviter de prendre trop vite la première release disponible.
+
+`Ratio Boost` sert surtout aux setups orientés torrents: les torrents peuvent être pris immédiatement, tandis que l'usenet attend pour laisser la priorité au torrent.
 
 ## Taille des fichiers
 

--- a/ops/4.delay-profiles.sql
+++ b/ops/4.delay-profiles.sql
@@ -3,6 +3,11 @@
 -- Reorganised from the initial Profilarr V2 import for maintainability
 -- ============================================================================
 
--- Delay values aligned with Dictionarry current defaults
+-- Default delay values aligned with Dictionarry current defaults.
 INSERT INTO delay_profiles (name, preferred_protocol, usenet_delay, torrent_delay, bypass_if_highest_quality, bypass_if_above_custom_format_score, minimum_custom_format_score) VALUES ('Radarr', 'prefer_torrent', 360, 360, 0, 0, NULL);
 INSERT INTO delay_profiles (name, preferred_protocol, usenet_delay, torrent_delay, bypass_if_highest_quality, bypass_if_above_custom_format_score, minimum_custom_format_score) VALUES ('Sonarr', 'prefer_torrent', 360, 360, 0, 0, NULL);
+
+-- Additional FR presets for users who want a clearer delay strategy.
+INSERT INTO delay_profiles (name, preferred_protocol, usenet_delay, torrent_delay, bypass_if_highest_quality, bypass_if_above_custom_format_score, minimum_custom_format_score) VALUES ('Ratio Boost', 'prefer_torrent', 360, 0, 0, 0, NULL);
+INSERT INTO delay_profiles (name, preferred_protocol, usenet_delay, torrent_delay, bypass_if_highest_quality, bypass_if_above_custom_format_score, minimum_custom_format_score) VALUES ('Balanced', 'prefer_torrent', 120, 120, 0, 0, NULL);
+INSERT INTO delay_profiles (name, preferred_protocol, usenet_delay, torrent_delay, bypass_if_highest_quality, bypass_if_above_custom_format_score, minimum_custom_format_score) VALUES ('Quality', 'prefer_torrent', 360, 360, 0, 0, NULL);


### PR DESCRIPTION
Ratio Boost : torrent immédiat, usenet retardé de 360 minutes
Balanced    : torrent et usenet retardés de 120 minutes
Quality     : torrent et usenet retardés de 360 minutes