### PR TITLE
French Missing fix

### DIFF
--- a/docs/fr-tier-conversion-map.json
+++ b/docs/fr-tier-conversion-map.json
@@ -32,7 +32,7 @@
     "2160p Compact FR keeps 1080p Efficient fallback below all 4KLight paths: 1080p source Efficient is 840000 and validated 1080p HEVC team tiers are lightweight 50000 bonuses, so the combined 890000 remains below 4KLight WEBRip at 900000.",
     "Historical FR source tiers are rebuilt without Global or Movie/TV splits: WEB Top, WEB, Bluray, UHD Bluray, Light, DVD and Unknown are the reusable source buckets.",
     "1080p Balanced FR is normalized in ops/22: reusable FR WEB tiers add small team bonuses, while the obsolete FR 1080p Balanced composite CF is removed.",
-    "French Missing (INTL) no longer treats a known French team as proof of French language by itself. A team only prevents the INTL missing-French penalty when combined with MULTi or MultiSub, or when the title has an explicit French marker. French language detected by Radarr or Sonarr also prevents the penalty, including for native French content."
+    "French Missing (INTL) no longer treats a known French team as proof of French language by itself. A team only prevents the INTL missing-French penalty when combined with MULTi or MultiSub, or when the title has an explicit French marker. Its optional French Except and Original Except language conditions form an OR group; only monolingual French-original metadata prevents the penalty without a trusted title marker."
   ],
   "aliases": {
     "FORWARD": "FW",
@@ -818,7 +818,7 @@
       "anime_profiles": "Anime 1080p FR uses MULTi/French Original > VOSTFR > VF on the 1,000,000-point scale. Anime 1080p VOSTFR FR shares the same technical and team scores but strictly rejects every non-VOSTFR language path.",
       "french_original": "French Original neutralizes the need for MULTi on native French or Quebec content, so a French-original release is not punished for not carrying a separate MULTi/VF tag.",
       "french_original_marker": "VOF and VOQ are treated as French Original markers. They prevent French Missing and VF/VFQ/VOSTFR penalties because they describe the original francophone version rather than an unwanted dub.",
-      "intl_trackers": "For international trackers, a French release group alone is not enough to prove French audio or subtitles. French Missing (INTL) is prevented by French language detected by Radarr or Sonarr, by explicit French markers, by MULTi + known French team, by MultiSub + known French team, or by VF/VOSTFR/VFQ/VOF/VOQ markers.",
+      "intl_trackers": "For international trackers, a French release group alone is not enough to prove French audio or subtitles. French Missing (INTL) is prevented by monolingual French-original metadata, by explicit French markers, by MULTi + known French team, by MultiSub + known French team, or by VF/VOSTFR/VFQ/VOF/VOQ markers.",
       "intl_dynamic_team_markers": "French MULTi + Team FR Marker (INTL) and French MultiSub + Team FR Marker (INTL) are regenerated from all regexes tagged French + Release Group, so newly added French teams are automatically covered."
     },
     "tier_policy": {

--- a/docs/languages-and-intl.md
+++ b/docs/languages-and-intl.md
@@ -90,7 +90,7 @@ Dans les profils FR prêts à l'emploi, ce Custom Format sert à éviter les dou
 
 ## French Missing
 
-`French Missing` se déclenche quand Radarr ou Sonarr ne détecte pas de langue française et qu'aucun marqueur français explicite n'est trouvé par les Custom Formats standards. Un contenu dont le français est la langue originale n'est donc pas considéré comme dépourvu de français, même si son titre ne contient aucun marqueur `FRENCH`, `VF` ou `VOF`.
+`French Missing` utilise deux conditions de langue alternatives: `French Except` ou `Original Except`. Il se déclenche donc lorsqu'au moins une langue détectée diffère du français ou de la langue originale, sauf lorsqu'un marqueur français reconnu neutralise le CF. Un contenu uniquement français dont le français est aussi la langue originale n'est pas considéré comme dépourvu de français, même si son titre ne contient aucun marqueur `FRENCH`, `VF` ou `VOF`.
 
 Il est pensé pour les trackers FR ou les profils qui acceptent `MULTi` comme preuve suffisante de français.
 
@@ -148,7 +148,7 @@ MultiSub.FRSUB
 
 `MULTi` seul ne suffit pas, `MultiSub` seul ne suffit pas non plus, et une team FR seule ne suffit pas non plus.
 
-`French Missing (INTL)` se déclenche quand Radarr ou Sonarr ne détecte pas de langue française et qu'il n'y a ni marqueur français explicite après `MULTi` ou `MultiSub`, ni combinaison fiable `MULTi + team FR` ou `MultiSub + team FR`, ni `VF`, ni `VOSTFR`, ni `VFQ`, ni `VOF` / `VOQ`.
+`French Missing (INTL)` utilise les mêmes conditions alternatives `French Except` ou `Original Except`. Il se déclenche lorsqu'au moins une langue détectée diffère du français ou de la langue originale et qu'il n'y a ni marqueur français explicite après `MULTi` ou `MultiSub`, ni combinaison fiable `MULTi + team FR` ou `MultiSub + team FR`, ni `VF`, ni `VOSTFR`, ni `VFQ`, ni `VOF` / `VOQ`.
 
 ## Comment utiliser les CF INTL
 

--- a/ops/1.custom-formats.sql
+++ b/ops/1.custom-formats.sql
@@ -80,7 +80,7 @@ INSERT INTO custom_formats (name, description) VALUES ('FR TV Remux Tier 01', 'M
 INSERT INTO custom_formats (name, description) VALUES ('FR TV WEB Tier 01', 'Matches French TV release groups who fall under WEB Tier 01');
 INSERT INTO custom_formats (name, description) VALUES ('FR TV WEB Tier 02', 'Matches French TV release groups who fall under WEB Tier 02');
 INSERT INTO custom_formats (name, description) VALUES ('FR TV WEB Tier 03', 'Matches French TV release groups who fall under WEB Tier 03');
-INSERT INTO custom_formats (name, description) VALUES ('French Missing', 'Rejects releases without detected French audio or an explicit French MULTi, French Original, VF, VOSTFR, or VFQ marker.');
+INSERT INTO custom_formats (name, description) VALUES ('French Missing', 'Rejects releases unless they are French-original content with only French detected, or carry an explicit French MULTi, French Original, VF, VOSTFR, or VFQ marker.');
 INSERT INTO custom_formats (name, description) VALUES ('French MULTi', 'Prioritizes French MULTi releases without also matching VFQ or VOSTFR.');
 INSERT INTO custom_formats (name, description) VALUES ('French Original Marker', 'Priorise les releases marquees VOF ou VOQ comme version originale francophone.');
 INSERT INTO custom_formats (name, description) VALUES ('French VF', 'Prioritizes French dubbed releases when they are not MULTi, VOSTFR, or VFQ.');
@@ -2882,9 +2882,13 @@ SELECT cf.name, 'Not French Original Marker', 'release_title', 'all', 1, 1
 FROM custom_formats cf
 WHERE cf.name = 'French Missing';
 INSERT INTO custom_format_conditions (custom_format_name, name, type, arr_type, negate, required)
-VALUES ('French Missing', 'Not French', 'language', 'all', 1, 1);
+VALUES ('French Missing', 'French Except', 'language', 'all', 0, 0);
 INSERT INTO condition_languages (custom_format_name, condition_name, language_name, except_language)
-VALUES ('French Missing', 'Not French', 'French', 0);
+VALUES ('French Missing', 'French Except', 'French', 1);
+INSERT INTO custom_format_conditions (custom_format_name, name, type, arr_type, negate, required)
+VALUES ('French Missing', 'Original Except', 'language', 'all', 0, 0);
+INSERT INTO condition_languages (custom_format_name, condition_name, language_name, except_language)
+VALUES ('French Missing', 'Original Except', 'Original', 1);
 INSERT INTO custom_format_conditions (custom_format_name, name, type, arr_type, negate, required)
 SELECT cf.name, 'French MULTi', 'release_title', 'all', 0, 1
 FROM custom_formats cf

--- a/ops/24.french-intl-multi-guards.sql
+++ b/ops/24.french-intl-multi-guards.sql
@@ -177,27 +177,44 @@ WHERE NOT EXISTS (
 
 INSERT INTO custom_formats (name, description)
 SELECT 'French Missing (INTL)',
-       'Matches INTL releases without detected French audio or a trusted French MULTi/MultiSub marker, French release group, VF, VOSTFR, VFQ or French original marker.'
+       'Matches INTL releases unless they are French-original content with only French detected, or carry a trusted French MULTi/MultiSub marker, VF, VOSTFR, VFQ or French original marker.'
 WHERE NOT EXISTS (
     SELECT 1 FROM custom_formats
     WHERE name = 'French Missing (INTL)'
 );
 
 INSERT INTO custom_format_conditions (custom_format_name, name, type, arr_type, negate, required)
-SELECT 'French Missing (INTL)', 'Not French', 'language', 'all', 1, 1
+SELECT 'French Missing (INTL)', 'French Except', 'language', 'all', 0, 0
 WHERE NOT EXISTS (
     SELECT 1 FROM custom_format_conditions
     WHERE custom_format_name = 'French Missing (INTL)'
-      AND name = 'Not French'
+      AND name = 'French Except'
 );
 
 INSERT INTO condition_languages (custom_format_name, condition_name, language_name, except_language)
-SELECT 'French Missing (INTL)', 'Not French', 'French', 0
+SELECT 'French Missing (INTL)', 'French Except', 'French', 1
 WHERE NOT EXISTS (
     SELECT 1 FROM condition_languages
     WHERE custom_format_name = 'French Missing (INTL)'
-      AND condition_name = 'Not French'
+      AND condition_name = 'French Except'
       AND language_name = 'French'
+);
+
+INSERT INTO custom_format_conditions (custom_format_name, name, type, arr_type, negate, required)
+SELECT 'French Missing (INTL)', 'Original Except', 'language', 'all', 0, 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM custom_format_conditions
+    WHERE custom_format_name = 'French Missing (INTL)'
+      AND name = 'Original Except'
+);
+
+INSERT INTO condition_languages (custom_format_name, condition_name, language_name, except_language)
+SELECT 'French Missing (INTL)', 'Original Except', 'Original', 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM condition_languages
+    WHERE custom_format_name = 'French Missing (INTL)'
+      AND condition_name = 'Original Except'
+      AND language_name = 'Original'
 );
 
 INSERT INTO custom_format_tags (custom_format_name, tag_name)


### PR DESCRIPTION
French NEGATE ET REQUIRED remplacer par : French Except et Original Except (ni NEGATE ni REQUIRED)

Créé un ou logique ne laissant passé que la VOF