### PR TITLE
fix(profile): Score 1080p Bluray in 1080p Balanced FR

### DIFF
--- a/ops/27.fix-1080p-balanced-bluray-score.sql
+++ b/ops/27.fix-1080p-balanced-bluray-score.sql
@@ -1,0 +1,20 @@
+-- @operation: export
+-- @entity: batch
+-- @name: Fix missing 1080p Bluray score in 1080p Balanced FR
+-- @description: Score the 1080p Bluray custom format in 1080p Balanced FR, whose Bluray-1080p quality was re-enabled without a matching source score.
+
+-- Bluray-1080p is part of the 1080p Balanced FR quality group (see
+-- 25.align-fr-profile-quality-groups-with-dictionarry.sql), but the technical
+-- score set rebuilt in 13.dictionarry-v2-technical-score-parity.sql never
+-- restored the matching 1080p Bluray custom format. A 1080p Bluray release
+-- therefore scored 0, below both 720p WEB-DL (660000) and the profile's
+-- minimum accepted score (20000), so it was rejected outright.
+--
+-- 700000 keeps the profile WEB-first: just under 1080p WEB-DL (710000) and
+-- above every 720p and lower source.
+DELETE FROM quality_profile_custom_formats
+WHERE quality_profile_name = '1080p Balanced FR'
+  AND custom_format_name = '1080p Bluray';
+
+INSERT INTO quality_profile_custom_formats (quality_profile_name, custom_format_name, arr_type, score)
+VALUES ('1080p Balanced FR', '1080p Bluray', 'all', 700000);


### PR DESCRIPTION
## Problème

Dans `1080p Balanced FR`, la qualité `Bluray-1080p` est activée dans le groupe de qualités, mais **aucun score n'est associé au Custom Format `1080p Bluray`** pour ce profil.

Conséquences dans Radarr / Sonarr :

1. Un BluRay 1080p score **0** sur la partie source, alors qu'un `720p WEB-DL` score 660000 → le 720p passe systématiquement devant.
2. Surtout, `minimum_custom_format_score` vaut 20000 pour ce profil. Un BluRay 1080p ne peut pas atteindre ce seuil (les tiers FR plafonnent à 5000) → **la release est rejetée**, alors que la qualité apparaît bien cochée dans l'interface.

C'est le seul trou de ce type : sur les 13 profils, toutes les autres qualités activées ont bien un CF de source scoré en face.

## Origine

Deux changements corrects pris séparément, dont l'interaction n'a pas été rejouée :

- `ops/13.dictionarry-v2-technical-score-parity.sql` purge les CF non-`FR %` / `French %` de chaque profil puis réinjecte un jeu technique complet. `1080p Bluray` n'y figure pas pour `1080p Balanced FR` — ce qui était cohérent à l'époque, le profil étant WEB-only côté qualités.
- `ops/25.align-fr-profile-quality-groups-with-dictionarry.sql` (issue #27) réécrit les pages Quality des 13 profils et réintroduit `Bluray-1080p` partout, y compris dans Balanced. Ce fichier ne touche que `quality_group_members`, jamais la table des scores.

Le profil jumeau `2160p Balanced FR` a bien `1080p Bluray` à 720000, ce qui confirme qu'il s'agit d'un oubli et non d'un choix de design.

## Correctif

Un seul fichier ajouté, `ops/27.fix-1080p-balanced-bluray-score.sql` : `DELETE` idempotent puis insertion de `('1080p Balanced FR', '1080p Bluray', 'all', 700000)`.

700000 place le BluRay 1080p **juste sous** `1080p WEB-DL` (710000) et au-dessus de toutes les sources inférieures. Le profil reste donc WEB-first, conformément à sa description (« cible des WEB-DL 1080p fiables et stables »), tout en rendant le BluRay 1080p à nouveau acceptable.

| CF source | avant | après |
| --- | --- | --- |
| `1080p WEB-DL` | 710000 | 710000 |
| `1080p Bluray` | *absent → 0* | **700000** |
| `720p WEB-DL` | 660000 | 660000 |
| `720p Bluray` | 540000 | 540000 |

## Vérification

J'ai rejoué l'intégralité des fichiers `ops/*.sql` dans l'ordre sur une base SQLite neuve, avant et après le correctif :

- le bug est bien présent sur `develop` dans son état actuel ;
- après correctif, `1080p Bluray` ressort à 700000 au bon rang ;
- aucun doublon introduit dans `quality_profile_custom_formats` ;
- une requête de cohérence « toute qualité activée a un CF de source scoré dans le même profil » ne remonte plus aucun cas sur les 13 profils (elle ne remontait que celui-ci).

## Notes

- PR ouverte sur `develop` conformément à `docs/index.md` (branche de validation avant publication).
- Aucun mot-clé de fermeture : la référence à #27 est du contexte, cette issue est déjà close et couvre un autre sujet.
- Sans rapport avec cette PR, mais repéré au passage : `.github/workflows/devSync.yml`, hérité d'upstream, fait un `git checkout dev` alors que la branche s'appelle `develop` ici — il doit échouer à chaque merge sur `stable`.
